### PR TITLE
Topology integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ data/
 enclave.dump/
 wsl-module/requirements.txt
 wsl-module/__pycache__
+config/network_topology_auto/

--- a/README.md
+++ b/README.md
@@ -64,11 +64,7 @@ there are 5 seconds (defined in `system_variables`) of waiting time for that nod
 
 Once all nodes are ready, prometheus and grafana will be set up and connected to all waku nodes.
 
-All nodes are then interconnected.
-
-A predefined number of test messages with specific delay (defined in `system_variables`) are sent by every node to the same topic.
-
-Peers from one node are requested, just for testing.
+Once all nodes have been interconnected the simulation starts and will inject traffic into the network following the parameters specified in the configuration file.
 
 #### Check Prometheus+Grafana+Logs
 

--- a/README.md
+++ b/README.md
@@ -16,30 +16,19 @@ More info about Kurtosis: https://docs.kurtosis.com/
 
 #### How to run
 
-If you want to run it with default arguments, if you are in the root of this repository, you can simply run:
+From the root of the repo run:
 
-`kurtosis run .`
+`sh ./run.sh` 
 
-Will load the default confiration .json file **./config/config.json**. You can also specify a different .json config file and its location:
+This will load the default confiration .json file **./config/config.json**. You can also specify a different .json config file and its location with:
 
-`kurtosis run . '{"config_file": "github.com/logos-co/wakurtosis/config/config.json"}'`
-
-The enclaves that will be created have randon names, that can be checked with:
-
-`kurtosis enclave ls`
-
-You can set up a pre-defined enclave name, for example:
-
-`kurtosis run --enclave-id wakurtosis .`
-
-Note that, if you try to run the same kurtosis module again, you will have clashes. You can clean previous enclaves with:
-
-`kurtosis clean -a`
+`sh ./run.sh ./config/config.json`
 
 #### JSON main configuration file options
 
 These are arguments that can be modified:
 
+- _enclave_name_: string. Default: **wakurtosis**. Defines the name of the Kurtosis enclave being created.
 - _same_toml_configuration_: boolean. Default: **true**. If **true**, the some `.toml` file will be applied to every Waku node. If **false*, every node will use its own `.toml` file.
 - _topology_file_: string. Default: **waku_test_topology_small.json**. If defines the network topology that will be created.
 - _simulation_time_: int. Default: **300**. Specifies the simulation time in seconds.
@@ -60,6 +49,13 @@ dist_type : "gaussian"
     # Values: uniform and gaussian
     inter_msg_type : "uniform"
 
+- _num_nodes_: int. Number of nodes in the enclave.
+- _num_topics_: int. Number of topics.
+- _node_type_: string. Type of node. Options are **desktop and **mobile**
+- _network_type_: string. Network topology. Options are **configmodel**, **scalefree**, **newmanwattsstrogatz**, **barbell**, **balancedtree**, and **star**
+- _num_partitions_: int. Number of partitions within the network.
+- _num_subnets_: int. Number of subnetworks.
+
 #### What will happen
 
 Kurtosis will automatically add one Waku node as container inside the enclave. The way that nodes are interconnected is given by the topology.
@@ -74,13 +70,18 @@ A predefined number of test messages with specific delay (defined in `system_var
 
 Peers from one node are requested, just for testing.
 
+#### Check Prometheus+Grafana+Logs
 
-#### Check Prometheus+Grafana
+- Simulation log:
 
-In order to know how to access to Prometheus or Grafana, run:
+'kurtosis service logs wakurtosis $(kurtosis enclave inspect <enclave-name> | grep wsl- | awk '{print $1}')'
 
-`kurtosis enclave inspect <enclave-name>`
+- Grafana server:
 
-With this, you will be able to see the ports exposed to your local machine.
+To display the IP address and Port of the Grafana server on your local machine run:
+
+'kurtosis enclave inspect <enclave-name> | grep grafana- | awk '{print $6}'
+
+Remember that by default <enclave-name> is 'wakurtosis'.
 
 Please, any improvements/bugs that you see, create an issue, and we will work on it.

--- a/config/config.json
+++ b/config/config.json
@@ -1,11 +1,18 @@
 {
+    "enclave_name" : "wakurtosis",
+    "topology_path" : "./config/network_topology_auto/",
     "same_toml_configuration": true,
-    "topology_file": "waku_test_topology_small.json",
     "simulation_time": 60,
     "message_rate": 10,
     "min_packet_size": 2,
     "max_packet_size": 1024,
     "inter_msg_type": "poisson",
     "dist_type": "gaussian",
-    "emitters_fraction": 1.0
+    "emitters_fraction": 1.0,
+    "num_nodes": 3,
+    "num_topics": 1,
+    "node_type": "desktop",
+    "network_type": "scalefree",
+    "num_partitions": 1,
+    "num_subnets" : 1
 }

--- a/gennet/generate_network.py
+++ b/gennet/generate_network.py
@@ -200,9 +200,9 @@ def generate_and_write_files(dirname, num_topics, num_subnets, G):
     for node in G.nodes:
         write_toml(dirname, node, generate_toml(topics))        # per node toml
         json_dump[node] = {}
-        json_dump[node]["static-nodes"] = []
+        json_dump[node]["static_nodes"] = []
         for edge in G.edges(node):
-            json_dump[node]["static-nodes"].append(edge[1])
+            json_dump[node]["static_nodes"].append(edge[1])
         json_dump[node][SUBNET_PREFIX] = subnets[node]
     write_json(dirname, json_dump)                              # network wide json
 

--- a/main.star
+++ b/main.star
@@ -15,12 +15,11 @@ def run(args):
     config_json = read_file(src=config_file)
     config = json.decode(config_json)
 
-    print(config)
-
     same_toml_configuration = config['same_toml_configuration']
     
     # Load network topology
-    waku_topology_json = read_file(src=system_variables.TOPOLOGIES_LOCATION + config['topology_file'])
+    # waku_topology_json = read_file(src=system_variables.TOPOLOGIES_LOCATION + 'network_data.json')
+    waku_topology_json = read_file(src="github.com/logos-co/wakurtosis/" + config['topology_path'] + 'network_data.json')
     waku_topology = json.decode(waku_topology_json)
 
     # Set up nodes

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Main .json configuration file
+config_file="./config/config.json"
+
+# Needs JQ to parse the main .json config file: 
+# sudo apt-get install jq
+# brew install jq
+
+enclave_name=$(cat $config_file | jq -r ".enclave_name")
+topology_path=$(cat $config_file | jq -r ".topology_path")
+num_nodes=$(cat $config_file | jq -r ".num_nodes")
+num_topics=$(cat $config_file | jq -r ".num_topics")
+node_type=$(cat $config_file | jq -r ".node_type")
+network_type=$(cat $config_file | jq -r ".network_type")
+num_partitions=$(cat $config_file | jq -r ".num_partitions")
+num_subnets=$(cat $config_file | jq -r ".num_subnets")
+
+# Generate the topology
+echo "Deleting previously generted topology in $topology_path ..."
+rm -rf $topology_path
+echo "Generating ./generate_network.py --dirname $topology_path --num-nodes $num_nodes --num-topics $num_topics --nw-type $network_type --node-type $node_type --num-partitions $num_partitions --num-subnets $num_subnets ...."
+./gennet/generate_network.py --dirname $topology_path --num-nodes $num_nodes --num-topics $num_topics --network-type $network_type --node-type $node_type --num-partitions $num_partitions --num-subnets $num_subnets
+
+# Delete the enclave 
+kurtosis enclave rm -f $enclave_name
+
+# Create the new enclave and run the simulation
+kurtosis run --enclave-id $enclave_name .
+
+# Fetch the WSL service id and display the log of the simulation
+wsl_service_id=$(kurtosis enclave inspect wakurtosis | grep wsl- | awk '{print $1}')
+kurtosis service logs wakurtosis $wsl_service_id
+echo "--> To see simulation logs run: kurtosis enclave inspect wakurtosis $wsl_service_id <--"
+
+# Fetch the Grafana address & port
+grafana_host=$(kurtosis enclave inspect wakurtosis | grep grafana- | awk '{print $6}')
+echo "--> Statistics in Grafana server at http://$grafana_host/ <--"

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
+# Parse arg if any
+ARGS1=${1:-"./config/config.json"}
+echo $ARGS1
+
 # Main .json configuration file
-config_file="./config/config.json"
+config_file=$ARGS1
 
 # Needs JQ to parse the main .json config file: 
 # sudo apt-get install jq
@@ -26,7 +30,8 @@ echo "Generating ./generate_network.py --dirname $topology_path --num-nodes $num
 kurtosis enclave rm -f $enclave_name
 
 # Create the new enclave and run the simulation
-kurtosis run --enclave-id $enclave_name .
+kurtosis_cmd="kurtosis run --enclave-id ${enclave_name} . '{\"config_file\" : \"github.com/logos-co/wakurtosis/${config_file}\"}'"
+eval $kurtosis_cmd
 
 # Fetch the WSL service id and display the log of the simulation
 wsl_service_id=$(kurtosis enclave inspect wakurtosis | grep wsl- | awk '{print $1}')

--- a/run.sh
+++ b/run.sh
@@ -36,7 +36,7 @@ eval $kurtosis_cmd
 # Fetch the WSL service id and display the log of the simulation
 wsl_service_id=$(kurtosis enclave inspect wakurtosis | grep wsl- | awk '{print $1}')
 kurtosis service logs wakurtosis $wsl_service_id
-echo "--> To see simulation logs run: kurtosis enclave inspect wakurtosis $wsl_service_id <--"
+echo "--> To see simulation logs run: kurtosis service logs wakurtosis $wsl_service_id <--"
 
 # Fetch the Grafana address & port
 grafana_host=$(kurtosis enclave inspect wakurtosis | grep grafana- | awk '{print $6}')

--- a/src/system_variables.star
+++ b/src/system_variables.star
@@ -53,7 +53,7 @@ SAME_TOML_CONFIGURATION = True
 # Topology
 TOPOLOGY_FILE_NAME = "topology"
 TOPOLOGIES_LOCATION = "github.com/logos-co/wakurtosis/config/network_topology/"
-DEFAULT_TOPOLOGY_FILE = "waku_test_topology_small.json"
+DEFAULT_TOPOLOGY_FILE = "network_data.json"
 
 NUMBER_TEST_MESSAGES = 50
 DELAY_BETWEEN_TEST_MESSAGE = "0.5"

--- a/src/wsl.star
+++ b/src/wsl.star
@@ -97,6 +97,4 @@ def set_up_wsl(services, simulation_time, message_rate, min_packet_size, max_pac
         )
     )
 
-    print('kurtosis service logs wakurtosis SERVICE-GUID')
-    
     return wsl_service


### PR DESCRIPTION
- Integrates the topology generation paramters into the global json configuration
- Implements a new entry point 'run.sh' that generates the topology, creates the Kurtosis enclave and runs the simulation
- The script also deletes any pre-existing Kurtosis enclave with the same name before trying to create a new one
- Updated the README.md to account for the changes, ie new process entry point and topology parameters
- Added helpers in README.md to show the Grafana host address and the simulation log file

Notes:
- In order to parse json from bash you will need to install JQ with 'sudo apt-get install jq'
- Run with 'sh ./run.sh' from the root of the repo

Solves #28 