### PR TITLE
Gennet updates

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -12,8 +12,7 @@
     "num_topics": 150,
     "num_partitions": 1,
     "num_subnets": 2,
-    "node_types": 2,
-    "node_type_distribution": { "type1":10, "type2":90},
+    "node_type_distribution": { "nwaku":50, "gowaku":50},
     "node_type": "desktop",
     "network_type": "scalefree",
     "output_dir": "generated_network"

--- a/config/config.json
+++ b/config/config.json
@@ -8,14 +8,15 @@
     "same_toml_configuration": false
   },
   "gennet": {
-    "num_nodes": 21,
+    "num_nodes": 121,
     "num_topics": 7,
     "num_partitions": 1,
     "num_subnets": 5,
     "node_type_distribution": { "nwaku":50, "gowaku":50},
     "node_type": "desktop",
     "network_type": "newmanwattsstrogatz",
-    "output_dir": "network_data"
+    "output_dir": "network_data",
+    "benchmark": "False"
   },
   "wsl": {
     "simulation_time": 60,

--- a/config/config.json
+++ b/config/config.json
@@ -8,14 +8,14 @@
     "same_toml_configuration": false
   },
   "gennet": {
-    "num_nodes": 100,
-    "num_topics": 150,
+    "num_nodes": 21,
+    "num_topics": 7,
     "num_partitions": 1,
-    "num_subnets": 2,
+    "num_subnets": 5,
     "node_type_distribution": { "nwaku":50, "gowaku":50},
     "node_type": "desktop",
-    "network_type": "scalefree",
-    "output_dir": "generated_network"
+    "network_type": "newmanwattsstrogatz",
+    "output_dir": "network_data"
   },
   "wsl": {
     "simulation_time": 60,

--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,6 @@
 {
   "general":{
-    "prng_seed" : 0
+    "prng_seed" : 67
   },
   "kurtosis": {
     "enclave_name": "wakurtosis",

--- a/config/config.json
+++ b/config/config.json
@@ -1,16 +1,22 @@
 {
+  "general":{
+    "prng_seed" : 0
+  },
   "kurtosis": {
     "enclave_name": "wakurtosis",
     "topology_path": "./config/topology_generated/",
     "same_toml_configuration": false
   },
   "gennet": {
-    "num_nodes": 3,
-    "num_topics": 1,
+    "num_nodes": 100,
+    "num_topics": 150,
+    "num_partitions": 1,
+    "num_subnets": 2,
+    "node_types": 2,
+    "node_type_distribution": { "type1":10, "type2":90},
     "node_type": "desktop",
     "network_type": "scalefree",
-    "num_partitions": 1,
-    "num_subnets": 1
+    "output_dir": "generated_network"
   },
   "wsl": {
     "simulation_time": 60,

--- a/gennet-module/Dockerfile
+++ b/gennet-module/Dockerfile
@@ -1,11 +1,31 @@
+# Create the build image
+FROM python:3.8-slim AS build-image
 
-FROM python
+# Create the virtualenv
+RUN python -m venv /opt/venv
 
-LABEL Maintainer="Daimakaimura"
+# Use the virtualenv
+ENV PATH="/opt/venv/bin:$PATH"
 
-WORKDIR /gennet
-COPY . .
-
+# Perform the installs
+COPY requirements.txt .
 RUN pip install -r requirements.txt
 
+# Create the production image
+FROM python:3.8-slim AS prod-image
+LABEL authors="0xFugue, Daimakaimura"
+#LABEL org.opencontainers.image.authors="0xFugue@github.com, Daimakaimura@github.com"
+
+# Copy the requisite files from the build image to the production image
+COPY --from=build-image /opt/venv /opt/venv
+
+# Copy the gennet files to the production image
+WORKDIR /gennet
+COPY Dockerfile batch_gen.sh gennet.py requirements.txt Readme.md ./
+
+# Deploy the virtualenv in production image
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Set the entrypoint
 ENTRYPOINT ["python", "gennet.py"]
+

--- a/gennet-module/Readme.md
+++ b/gennet-module/Readme.md
@@ -32,7 +32,7 @@ Our tool can also take arguments from a json file, specified using `--config-fil
 Following is an example json file:
 
 
-```json
+````json
 {
   "general":{
     "prng_seed" : 67

--- a/gennet-module/Readme.md
+++ b/gennet-module/Readme.md
@@ -1,52 +1,68 @@
-Module to generate network models (in JSON) and node configuration files (in TOMLs) for wakurtosis runs. 
+Module to generate network models (in JSON) and node configuration files (in TOMLs) for wakurtosis runs. It can be deployed in two ways: as a stand-alone python tool or as a docker.
 
-## generate_network.py
-generate_network.py generates one network and per-node configuration files. The tool is configurable with specified number of nodes, topics, network types, node types and number of subnets.
+## gennet cli
+`gennet.py` takes a range of CLI inputs, and outputs the network data --- in the form of a `network_data.json` file and a set of per-node TOML files. 
 
 ```commandline
 > python gennet.py --help
-
-Usage: gennet.py [OPTIONS]
-
-Options:
-  --output-dir TEXT               [default: topology_generated]
-  --num-nodes INTEGER             [default: 4]
-  --num-topics INTEGER            [default: 1]
-  --network-type [configmodel|scalefree|newmanwattsstrogatz|barbell|balancedtree|star]
-                                  [default: newmanwattsstrogatz]
-  --node-type [desktop|mobile]    [default: desktop]
-  --num-subnets INTEGER           [default: -1]
-  --num-partitions INTEGER        [default: 1]
-  --config-file TEXT
-  --help                          Show this message and exit.
+ Usage: gennet.py [OPTIONS]                                                     
+                                                                                
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --benchmark         --no-benchmark                        [default:          │
+│                                                           no-benchmark]      │
+│ --output-dir                          TEXT                [default: network_data]                   │
+│ --prng-seed                           INTEGER             [default: 1]      │
+│ --num-nodes                           INTEGER             [default: 4]      │
+│ --num-topics                          INTEGER             [default: 1]      │
+│ --network-type                        [configmodel|scale  [default:          │
+│                                       free|newmanwattsst  newmanwattsstroga… │
+│                                       rogatz|barbell|bal                     │
+│                                       ancedtree|star|]                       │
+│ --num-partitions                      INTEGER             [default: 1]      │
+│ --num-subnets                         INTEGER             [default: -1]      │
+│ --config-file                         TEXT                                   │
+│ --help                                                    Show this message  │
+│                                                           and exit.          │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
-CLI arguments have precedence from configuration file.
+Our tool can also take arguments from a json file, specified using `--config-file` option.
 
-Example of configuration file:
+
+Following is an example json file:
+
 
 ```json
 {
+  "general":{
+    "prng_seed" : 67
+  },
   "gennet": {
-    "num_nodes": 3,
-    "num_topics": 1,
+    "num_nodes": 100,
+    "num_topics": 150,
+    "num_partitions": 1,
+    "num_subnets": 2,
+    "node_type_distribution": { "nwaku":50, "gowaku":50},
     "node_type": "desktop",
     "network_type": "scalefree",
-    "num_partitions": 1,
-    "num_subnets": 1
+    "output_dir": "generated_network"
   }
 }
 ```
 
-It has also a Dockerfile to run it in a docker container. Example assuming our configiguration file is in `config` folder:
+Note that CLI arguments take precedence over the configuration file options.
+
+## gennet docker
+The gennet module can also be run as a docker. The Dockerfile provided can be used to build and run the gennet container as follows:
+
 
 ```commandline
 > docker build -t gennet .
 
-> docker run --name gennet-container -v ${dir}/config/:/config gennet --config-file /config/my_config_file.json --output-dir /config/topology_generated
+> docker run --name gennet-container -v ${dir}/config/:/config gennet --config-file /config/$input_config_file --output-dir /config/$output_dir
 ```
 
-In this way, it will mount `config` as a volume, allowing the docker container to get our `my_config_file.json`, and writing the results on a new folder called `topology_generated` which as it will be in `config`, the host will have access to it.
+When run this way, the docker will mount the host's `config` dir as a volume, allowing the gennet container to access the `$input_config_file` in the host filesystem; gennet reads the config.json and outputs a network under the `$output_dir` which is made accessible to the host via a subsequent`docker cp`.
 
 
 ## batch_gen.sh

--- a/gennet-module/Readme.md
+++ b/gennet-module/Readme.md
@@ -6,24 +6,25 @@ Module to generate network models (in JSON) and node configuration files (in TOM
 ```commandline
 > python gennet.py --help
  Usage: gennet.py [OPTIONS]                                                     
+
+              
+╭─ Options ────────────────────────────────────────────────────────────────────────────╮
+│ --benchmark         --no-benchmark                           [default: no-benchmark] │
+│ --output-dir                          TEXT                   [default: network_data] │
+│ --prng-seed                           INTEGER                [default: 3]            │
+│ --num-nodes                           INTEGER                [default: 4]            │
+│ --num-topics                          INTEGER                [default: 1]            │
+│ --network-type                        [configmodel|scalefree [default:               │
+│                                       |newmanwattsstrogatz   newmanwattsstrogatz]    │
+│                                       |barbell|balancedtree                          │
+│                                       |star]                                         │
+│ --num-subnets                         INTEGER                [default: 1]            │
+│ --num-partitions                      INTEGER                [default: 1]            │
+│ --config-file                         TEXT                                           │
+│ --help                                                       Show this message and   │
+│                                                              exit.                   │
+╰──────────────────────────────────────────────────────────────────────────────────────╯
                                                                                 
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --benchmark         --no-benchmark                        [default:          │
-│                                                           no-benchmark]      │
-│ --output-dir                          TEXT                [default: network_data]                   │
-│ --prng-seed                           INTEGER             [default: 1]      │
-│ --num-nodes                           INTEGER             [default: 4]      │
-│ --num-topics                          INTEGER             [default: 1]      │
-│ --network-type                        [configmodel|scale  [default:          │
-│                                       free|newmanwattsst  newmanwattsstroga… │
-│                                       rogatz|barbell|bal                     │
-│                                       ancedtree|star|]                       │
-│ --num-partitions                      INTEGER             [default: 1]      │
-│ --num-subnets                         INTEGER             [default: -1]      │
-│ --config-file                         TEXT                                   │
-│ --help                                                    Show this message  │
-│                                                           and exit.          │
-╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 Our tool can also take arguments from a json file, specified using `--config-file` option.

--- a/gennet-module/Readme.md
+++ b/gennet-module/Readme.md
@@ -32,7 +32,7 @@ Our tool can also take arguments from a json file, specified using `--config-fil
 Following is an example json file:
 
 
-````json
+```json
 {
   "general":{
     "prng_seed" : 67

--- a/gennet-module/gennet.py
+++ b/gennet-module/gennet.py
@@ -1,14 +1,12 @@
 #! /usr/bin/env python3
 
 import matplotlib.pyplot as plt
-import yaml
-
 import networkx as nx
 import numpy as np
 
 import random, math
-import json
 import sys, os
+import json
 
 import time, tracemalloc
 import string
@@ -31,7 +29,7 @@ defaults = {
         "num_topics" : 1,
         "node_type_distribution": { "nwaku" : 100 },
         "network_type" : "scalefree",
-        "output_dir" : "generated_network",
+        "output_dir" : "network_data",
         "prng_seed" : 1
         }
 
@@ -320,7 +318,8 @@ def test_and_set_str(cli_val, file_val, conf, module="gennet"):
     return defaults[file_val]
 
 
-def main(output_dir: str = STR_NONE,
+def main(benchmark : bool = False,
+         output_dir: str = STR_NONE,
          prng_seed: int = INT_NONE,
          num_nodes: int = INT_NONE,
          num_topics: int = INT_NONE,
@@ -330,8 +329,9 @@ def main(output_dir: str = STR_NONE,
          config_file: str = typer.Option(STR_NONE, callback=conf_callback, is_eager=True)):
 
     # Benchmarking: record start time and start tracing mallocs
-    start = time.time()
-    tracemalloc.start()
+    if benchmark :
+        start = time.time()
+        tracemalloc.start()
 
 
     conf = {}
@@ -351,7 +351,7 @@ def main(output_dir: str = STR_NONE,
     if "gennet" in conf  and "node_type_distribution" in conf ["gennet"]:
         node_type_distribution = conf["gennet"]["node_type_distribution"]
     else:
-        node_type_distribution = default["node_type_distribution"]
+        node_type_distribution = defaults["node_type_distribution"]
 
     # merge the cli options and the config.json options
     # TODO : pack the fields in a class/'struct'/tuple
@@ -373,14 +373,14 @@ def main(output_dir: str = STR_NONE,
     # Generate file format specific data structs and write the files
     generate_and_write_files(output_dir, num_topics, num_subnets, node_type_distribution, G)
     #draw(G, outpur_dir)
+    print(f"Network generation is done.\nThe generated network is under ./{output_dir}")
 
     # Benchmarking. Record finish time and stop the malloc tracing
-    end = time.time()
-    mem_curr, mem_max = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
-
-    print(f"Network generation is done.\nThe generated network is under ./{output_dir}")
-    print(f"STATS: For {num_nodes} nodes, time took is {(end-start)} secs, peak memory usage is {mem_max/(1024*1024)} MBs\n")
+    if benchmark :
+        end = time.time()
+        mem_curr, mem_max = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        print(f"STATS: For {num_nodes} nodes, time took is {(end-start)} secs, peak memory usage is {mem_max/(1024*1024)} MBs\n")
 
 
 if __name__ == "__main__":

--- a/gennet-module/gennet.py
+++ b/gennet-module/gennet.py
@@ -2,7 +2,10 @@
 
 import matplotlib.pyplot as plt
 import yaml
+
 import networkx as nx
+import numpy as np
+
 import random, math
 import json
 import sys, os
@@ -269,9 +272,6 @@ def conf_callback(ctx: typer.Context, param: typer.CallbackParam, cfile: str):
                     sys.exit(1)
                 print(conf)
 
-            #set the random seed
-            random.seed(conf['general']['prng_seed'])
-
             ctx.default_map = ctx.default_map or {}  # Initialize the default map
             ctx.default_map.update(conf)  # Merge the config dict into default_map
         except Exception as ex:
@@ -310,6 +310,12 @@ def main(output_dir: str = STR_NONE,
             conf = json.load(f)
         #print(conf)
 
+    #set the random seed : networkx uses numpy as well
+    if "general" in conf  and "prng_seed" in conf ["general"]:
+        seed = conf["general"]["prng_seed"] 
+        print("Setting the random seed", seed)
+        random.seed(seed)
+        np.random.seed(seed)
     
     # merge the cli options and the config.json options
     # TODO : type check and sanity check config.json parameters

--- a/gennet-module/gennet.py
+++ b/gennet-module/gennet.py
@@ -287,7 +287,7 @@ def _num_subnets_callback(ctx: typer, Context, num_subnets: int):
     return num_subnets
 
 
-def main(ctx: typer.Context, benchmark : bool = False,
+def main(benchmark: bool = False,
          output_dir: str = "network_data",
          prng_seed: int = 3,
          num_nodes: int = 4,

--- a/gennet-module/gennet.py
+++ b/gennet-module/gennet.py
@@ -28,7 +28,7 @@ defaults = {
         "num_subnets" : 1,
         "num_topics" : 1,
         "node_type_distribution": { "nwaku" : 100 },
-        "network_type" : "scalefree",
+        "network_type" : "newmanwattsstrogatz",
         "output_dir" : "network_data",
         "prng_seed" : 1
         }

--- a/gennet-module/gennet.py
+++ b/gennet-module/gennet.py
@@ -280,7 +280,7 @@ def conf_callback(ctx: typer.Context, param: typer.CallbackParam, cfile: str):
 
 
 # methods to merge cli values, config.json and default values
-def testAndSetInt(cli_val, file_val, conf):
+def test_and_set_int(cli_val, file_val, conf):
     if cli_val != INT_NONE:
         return cli_val
     if cli_val == INT_NONE and "gennet" in conf and file_val in conf["gennet"]:
@@ -288,7 +288,7 @@ def testAndSetInt(cli_val, file_val, conf):
     return defaults[file_val]
 
 
-def testAndSetStr(cli_val, file_val, conf):
+def test_and_set_str(cli_val, file_val, conf):
     if cli_val != STR_NONE:
         return cli_val
     if cli_val == STR_NONE and "gennet" in conf and file_val in conf["gennet"]:
@@ -320,12 +320,12 @@ def main(output_dir: str = STR_NONE,
     # merge the cli options and the config.json options
     # TODO : type check and sanity check config.json parameters
     # TODO : use inspect and local() to do this iteratively
-    output_dir      =   testAndSetStr(output_dir, "output_dir", conf)
-    num_nodes       =   testAndSetInt(num_nodes, "num_nodes", conf)
-    num_topics      =   testAndSetInt(num_topics, "num_topics", conf)
-    network_type    =   testAndSetInt(network_type, "network_type", conf)
-    num_partitions  =   testAndSetInt(num_partitions, "num_partitions", conf)
-    num_subnets     =   testAndSetInt(num_subnets, "num_subnets", conf)
+    output_dir      =   test_and_set_str(output_dir, "output_dir", conf)
+    num_nodes       =   test_and_set_int(num_nodes, "num_nodes", conf)
+    num_topics      =   test_and_set_int(num_topics, "num_topics", conf)
+    network_type    =   test_and_set_int(network_type, "network_type", conf)
+    num_partitions  =   test_and_set_int(num_partitions, "num_partitions", conf)
+    num_subnets     =   test_and_set_int(num_subnets, "num_subnets", conf)
 
     # Generate the network
     G = generate_network(num_nodes, networkType(network_type))

--- a/gennet-module/gennet.py
+++ b/gennet-module/gennet.py
@@ -13,16 +13,16 @@ from enum import Enum
 
 # Enums & Consts
 
-# to facilitate merge of config.json and cli
+# to facilitate merge of cli inputs, config.json and defaults
 INT_NONE = -1
 STR_NONE = ""
 
-
+# the param defaults
 defaults = {
         "num_nodes": 4,
         "num_partitions": 1,
         "num_subnets": 1,
-        "num_topics": 2,
+        "num_topics": 1,
         "node_types": 2,
         "node_type_distribution": { "type1":10, "type2":90},
         "network_type": "scalefree",
@@ -279,6 +279,7 @@ def conf_callback(ctx: typer.Context, param: typer.CallbackParam, cfile: str):
     return cfile
 
 
+# methods to merge cli values, config.json and default values
 def testAndSetInt(cli_val, file_val, conf):
     if cli_val != INT_NONE:
         return cli_val
@@ -309,8 +310,10 @@ def main(output_dir: str = STR_NONE,
             conf = json.load(f)
         #print(conf)
 
+    
     # merge the cli options and the config.json options
     # TODO : type check and sanity check config.json parameters
+    # TODO : use inspect and local() to do this iteratively
     output_dir      =   testAndSetStr(output_dir, "output_dir", conf)
     num_nodes       =   testAndSetInt(num_nodes, "num_nodes", conf)
     num_topics      =   testAndSetInt(num_topics, "num_topics", conf)

--- a/gennet-module/requirements.txt
+++ b/gennet-module/requirements.txt
@@ -15,7 +15,6 @@ packaging==22.0
 Pillow==9.3.0
 pyparsing==3.0.9
 python-dateutil==2.8.2
-PyYAML==6.0
 requests==2.28.1
 scipy==1.10.0
 six==1.16.0


### PR DESCRIPTION
-  gennet now reads and uses config.json
-   config.json and cli arguments are now correctly prioritised
-  the gennet module defaults are enforced correctly
-  output file can now be set with config.json
-  the prng_seed is now set correctly; can be set using config.json as well

----------

-  fixed topic generation bug, simplified and optimised the code
-  added prng_seed cli arg and prioritise it with config.json
-  the node type distribution can be set using config.json; NO cli equivalent
-  gennet can generate node types following a distribution; default is 100% nwaku nodes
-  added execution time, peak memory usage stats 
-  gennet can now scale to half a  million nodes  (~60/75 secs, without/with memory tracing)

----------

- added a two stage build for gennet: gennet docker size is now at 330MB, down from 1.4GB
- benchmarking can now be turned on and off using a cli option
- some minor code cleanups, added back the old merge code
- updated the Readme
- benchmark can now be set using config.json

----------

- closes #67 , #66 , #63 ,  #61, #60 , #59 , #49 