### PR TITLE
Added cadvisor to run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,10 @@
 
 dir=$(pwd)
 
+# Set up Cadvisor
+docker run --volume=/:/rootfs:ro --volume=/var/run:/var/run:rw --volume=/var/lib/docker/:/var/lib/docker:ro --volume=/dev/disk/:/dev/disk:ro --volume=/sys:/sys:ro --volume=/etc/machine-id:/etc/machine-id:ro --publish=8080:8080 --detach=true --name=cadvisor --privileged --device=/dev/kmsg gcr.io/cadvisor/cadvisor
+
+
 # Parse arg if any
 ARGS1=${1:-"wakurtosis"}
 ARGS2=${2:-"config.json"}


### PR DESCRIPTION
Related with #58 

After some struggling I managed to make this work in my computer. It can have access to all the containers inside the enclave without any problem.

We can have access to:
- CPU total usage
- CPU Usage per Core
- CPU Usage Breakdown
- Ram usage
- Network

I will let the code I did in `Alberto/parall/cadvisor` branch there just in case we can set this up in the enclave but I don't think that will be the case, at least using Docker, I don't know about Kubernetes.

The problem is that the more things we do outside the enclave, the worse will be the transition between kurtosis with docker and with kubernetes I guess.

**More information:**

- [How to use it standalone, without Docker](https://github.com/google/cadvisor/blob/master/docs/running.md#standalone)
- [How to deploy it in Kubernetes](https://github.com/google/cadvisor/tree/master/deploy/kubernetes)
- [How to export stats ](https://github.com/google/cadvisor/blob/master/docs/storage/README.md)(including Prometheus)
- [Rest API](https://github.com/google/cadvisor/blob/master/docs/api.md)

Closes #42 

Before merging, please checkout to this branch and try it by yourself. Because I had to emulate some things due to being Windows user. I expect that this should work, but we need to check it before merging.