### PR TITLE
Modified runner and wakurtosis to add cadvisor to the enclave

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ More info about Kurtosis: https://docs.kurtosis.com/
 
 #### Before using this repository note that: 
 
-- **You are using Kurtosis version 0.66.2**. This is important, as they are working on it and changes can be huge depending on different versions. You can find all Kurtosis versions [here](https://github.com/kurtosis-tech/kurtosis-cli-release-artifacts/releases).
+- **You are using Kurtosis version 0.67.1**. This is important, as they are working on it and changes can be huge depending on different versions. You can find all Kurtosis versions [here](https://github.com/kurtosis-tech/kurtosis-cli-release-artifacts/releases).
 - The topology files that will be used by default are defined in `config/topology_generated/`. This topology is created with the [gennet](gennet-module/Readme.md) module.
 - Kurtosis can set up services in a parallel manner, defined in the `config.json` file (see below).
 - Only `kurtosis` and `docker` are needed to run this.

--- a/build.sh
+++ b/build.sh
@@ -2,8 +2,10 @@
 sudo apt-get update
 sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
+apt-get install -y jq
+
 # Install the suitable kurtosis-cli
-kurtosis_version=0.66.2
+kurtosis_version=0.67.1
 echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
 sudo apt update
 sudo apt-mark unhold kurtosis-cli

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -11,3 +11,7 @@ scrape_configs:
     file_sd_configs:
     - files:
       - '/tmp/targets.json'
+  - job_name: 'cadvisor'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['cadvisor:8080']


### PR DESCRIPTION
In this PR I added cAdvisor to the enclave, so it is able to see networking statistics from the nodes, and it dumbs the information into prometheus.

Also updated kurtosis version.

Note that the changes in `prometheus.yml` is intended for a Linux system because of how Docker works. If Linux is not being used,  it needs to be changed to:
```
  - job_name: 'cadvisor'
    scrape_interval: 5s
    static_configs:
    - targets:
      - 'host.docker.internal:8080'
```

This can be checked when accessing to Prometheus UI in any webbrowser, Status -> Targets. There cadvsior should have an "UP" state if it is correctly connected.