### PR TITLE
Gennet: traits and complete configurability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ config/network_topology_auto/
 config/config.json
 gennet-module/topology/
 gennet-module/network_data/
-gennet-module/traits/
+gennet-module/traits
 kurtosis_log.txt
 config/network_topology/
 config/topology_generated/

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ wls-module/__pycache__
 config/network_topology_auto/
 config/config.json
 gennet-module/topology/
+gennet-module/network_data/
 kurtosis_log.txt
 config/network_topology/
 config/topology_generated/

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ config/network_topology_auto/
 config/config.json
 gennet-module/topology/
 gennet-module/network_data/
+gennet-module/traits/
 kurtosis_log.txt
 config/network_topology/
 config/topology_generated/

--- a/config/config.json
+++ b/config/config.json
@@ -16,10 +16,6 @@
     "num_subnets": 1,
     "container_size": "1",
     "node_type_distribution": { "nwaku":100, "gowaku":0 },
-    "node_config": {
-      "nwaku": "rpc-admin = true\nkeep-alive = true\nmetrics-server = true\ndiscv5-discovery = true\n",
-      "gowaku": "rpc-admin = true\nmetrics-server = true\nrpc = true\n"
-    },
     "network_type": "newmanwattsstrogatz",
     "output_dir": "network_data",
     "benchmark": "False"

--- a/config/traits/discv5.toml
+++ b/config/traits/discv5.toml
@@ -11,6 +11,6 @@
 #                               enable/disable this functionality [=false].
 
 discv5-discovery=false
-discv5-udp-port=
-discv5-bootstrap-node=
-discv5-enr-auto-update=
+#discv5-udp-port=
+#discv5-bootstrap-node=
+#discv5-enr-auto-update=

--- a/config/traits/discv5.toml
+++ b/config/traits/discv5.toml
@@ -1,0 +1,16 @@
+# --discv5-discovery        Enable discovering nodes via Node Discovery v5
+#                               [=false].
+# --discv5-udp-port         Listening UDP port for Node Discovery v5.
+#                               [=9000].
+# --discv5-bootstrap-node   Text-encoded ENR for bootstrap node. Used when
+#                               connecting to the network. Argument may be
+#                               repeated..
+# --discv5-enr-auto-update  Discovery can automatically update its ENR with
+#                               the IP address and UDP port as seen by other
+#                               nodes it communicates with. This option allows to
+#                               enable/disable this functionality [=false].
+
+discv5-discovery=false
+discv5-udp-port=
+discv5-bootstrap-node=
+discv5-enr-auto-update=

--- a/config/traits/dns.toml
+++ b/config/traits/dns.toml
@@ -1,0 +1,13 @@
+# --dns-addrs               Enable resolution of `dnsaddr`, `dns4` or `dns6`
+#                               multiaddrs [=true].
+# --dns-addrs-name-server   DNS name server IPs to query for DNS multiaddrs
+#                               resolution. Argument may be repeated.
+#                               [=@[ValidIpAddress.init("1.1.1.1"),
+#                               ValidIpAddress.init("1.0.0.1")]].
+# --dns4-domain-name        The domain name resolving to the node's public
+#                               IPv4 address.
+
+
+dns-addrs=true
+dns-addrs-name-server=
+dns4-domain-name=

--- a/config/traits/dns.toml
+++ b/config/traits/dns.toml
@@ -9,5 +9,5 @@
 
 
 dns-addrs=true
-dns-addrs-name-server=
-dns4-domain-name=
+#dns-addrs-name-server=
+#dns4-domain-name=

--- a/config/traits/dnsdisc.toml
+++ b/config/traits/dnsdisc.toml
@@ -1,0 +1,7 @@
+# --dns-discovery              Enable DNS Discovery
+# --dns-discovery-url          URL for DNS node list in format 'enrtree://<key>@<fqdn>'
+# --dns-discovery-name-server  DNS name server IPs to query. Argument may be repeated.
+
+dns-discovery=false
+dns-discovery-url=
+dns-discover-name-server=

--- a/config/traits/dnsdisc.toml
+++ b/config/traits/dnsdisc.toml
@@ -3,5 +3,5 @@
 # --dns-discovery-name-server  DNS name server IPs to query. Argument may be repeated.
 
 dns-discovery=false
-dns-discovery-url=
-dns-discover-name-server=
+#dns-discovery-url=
+#dns-discover-name-server=

--- a/config/traits/filter.toml
+++ b/config/traits/filter.toml
@@ -1,0 +1,8 @@
+# --filter                  Enable filter protocol: true|false [=false].
+# --filternode              Peer multiaddr to request content filtering of
+#                               messages..
+# --filter-timeout          Timeout for filter node in seconds. [=14400].
+
+filter=false
+filternode=
+filter-timeout=14400

--- a/config/traits/flter.toml
+++ b/config/traits/flter.toml
@@ -4,5 +4,5 @@
 # --filter-timeout          Timeout for filter node in seconds. [=14400].
 
 filter=false
-filternode=
+#filternode=
 filter-timeout=14400

--- a/config/traits/lightpush.toml
+++ b/config/traits/lightpush.toml
@@ -3,4 +3,4 @@
 #                               messages..
 
 lightpush=false
-lightpushnode=
+#lightpushnode=

--- a/config/traits/lightpush.toml
+++ b/config/traits/lightpush.toml
@@ -1,0 +1,6 @@
+#--lightpush               Enable lightpush protocol: true|false [=false].
+#--lightpushnode           Peer multiaddr to request lightpush of published
+#                               messages..
+
+lightpush=false
+lightpushnode=

--- a/config/traits/metrics.toml
+++ b/config/traits/metrics.toml
@@ -1,0 +1,12 @@
+# --metrics-server          Enable the metrics server: true|false [=false].
+# --metrics-server-address  Listening address of the metrics server.
+#                               [=ValidIpAddress.init("127.0.0.1")].
+# --metrics-server-port     Listening HTTP port of the metrics server.
+#                               [=8008].
+# --metrics-logging         Enable metrics logging: true|false [=true].
+#                               ValidIpAddress.init("1.0.0.1")]].
+
+metrics-server=false
+metrics-server-address=
+metrics-server-port=
+metrics-logging=

--- a/config/traits/metrics.toml
+++ b/config/traits/metrics.toml
@@ -7,6 +7,6 @@
 #                               ValidIpAddress.init("1.0.0.1")]].
 
 metrics-server=false
-metrics-server-address=
-metrics-server-port=
-metrics-logging=
+#metrics-server-address=
+metrics-server-port=8008
+#metrics-logging=

--- a/config/traits/node.toml
+++ b/config/traits/node.toml
@@ -29,9 +29,9 @@
 #                               may be repeated..
 
 agent-string="nwaku"
-nodekey=
+#nodekey=
 
-config-file=
+#config-file=
 log-level=logging.LogLevel.INFO
 log-format=logging.LogFormat.TEXT
 listen-address=
@@ -44,8 +44,8 @@ max-connections=50
 
 ports-shift=0
 nat=any
-ext-multiaddr=
-staticnode=
+#ext-multiaddr=
+#staticnode=
 
 
 # --topics                  Default topics to subscribe to (space separated

--- a/config/traits/node.toml
+++ b/config/traits/node.toml
@@ -1,0 +1,52 @@
+# --agent-string            Node agent string which is used as identifier in
+#                               network [=nwaku].
+# --nodekey                 P2P node private key as 64 char hex string..
+#
+#
+# --config-file             Loads configuration from a TOML file (cmd-line
+#                               parameters take precedence).
+# --log-level               Sets the log level for process. Supported levels:
+#                               TRACE, DEBUG, INFO, NOTICE, WARN, ERROR or FATAL
+#                               [=logging.LogLevel.INFO].
+# --log-format              Specifies what kind of logs should be written to
+#                               stdout. Suported formats: TEXT, JSON
+#                               [=logging.LogFormat.TEXT].
+#  --listen-address          Listening address for LibP2P (and Discovery v5,
+#                               if enabled) traffic. [=defaultListenAddress()].
+# --tcp-port                TCP listening port. [=60000].
+# --keep-alive              Enable keep-alive for idle connections:
+#                               true|false [=false].
+# --max-connections         Maximum allowed number of libp2p connections.
+#                               [=50].
+#
+# --ports-shift             Add a shift to all port numbers. [=0].
+# --nat                     Specify method to use for determining public
+#                               address. Must be one of: any, none, upnp, pmp,
+#                               extip:<IP>. [=any].
+# --ext-multiaddr           External multiaddresses to advertise to the
+#                               network. Argument may be repeated..
+# --staticnode              Peer multiaddr to directly connect with. Argument
+#                               may be repeated..
+
+agent-string="nwaku"
+nodekey=
+
+config-file=
+log-level=logging.LogLevel.INFO
+log-format=logging.LogFormat.TEXT
+listen-address=
+tcp-port=60000
+
+
+keep-alive=false
+max-connections=50
+
+
+ports-shift=0
+nat=any
+ext-multiaddr=
+staticnode=
+
+
+# --topics                  Default topics to subscribe to (space separated
+#                               list). [=/waku/2/default-waku/proto].

--- a/config/traits/peer.toml
+++ b/config/traits/peer.toml
@@ -1,5 +1,5 @@
 # --peer-store-capacity     Maximum stored peers in the peerstore..
 # --peer-persistence        Enable peer persistence. [=false].
 
-peer-store-capacity=
+#peer-store-capacity=
 peer-persistence=false

--- a/config/traits/peer.toml
+++ b/config/traits/peer.toml
@@ -1,0 +1,5 @@
+# --peer-store-capacity     Maximum stored peers in the peerstore..
+# --peer-persistence        Enable peer persistence. [=false].
+
+peer-store-capacity=
+peer-persistence=false

--- a/config/traits/peerxchng.toml
+++ b/config/traits/peerxchng.toml
@@ -5,4 +5,4 @@
 
 
 peer-exchange=false
-peer-exchange-node=
+#peer-exchange-node=

--- a/config/traits/peerxchng.toml
+++ b/config/traits/peerxchng.toml
@@ -1,0 +1,8 @@
+# --peer-exchange           Enable waku peer exchange protocol (responder
+#                               side): true|false [=false].
+# --peer-exchange-node      Peer multiaddr to send peer exchange requests to.
+#                               (enables peer exchange protocol requester side).
+
+
+peer-exchange=false
+peer-exchange-node=

--- a/config/traits/relay.toml
+++ b/config/traits/relay.toml
@@ -1,0 +1,6 @@
+# --relay                   Enable relay protocol: true|false [=true].
+# --relay-peer-exchange     Enable gossipsub peer exchange in relay protocol:
+#                               true|false [=false].
+
+relay=true
+relay-peer-exchange=false

--- a/config/traits/rest.toml
+++ b/config/traits/rest.toml
@@ -1,0 +1,18 @@
+# --rest                    Enable Waku REST HTTP server: true|false
+#                               [=false].
+# --rest-address            Listening address of the REST HTTP server.
+#                               [=ValidIpAddress.init("127.0.0.1")].
+# --rest-port               Listening port of the REST HTTP server. [=8645].
+# --rest-relay-cache-capacity  Capacity of the Relay REST API message cache.
+#                               [=30].
+# --rest-admin              Enable access to REST HTTP Admin API: true|false
+#                               [=false].
+# --rest-private            Enable access to REST HTTP Private API:
+#                               true|false [=false].
+
+rest=false
+rest-address=
+rest-port=
+rest-relay-cache-capacity=
+#rest-admin=
+rest-private=

--- a/config/traits/rest.toml
+++ b/config/traits/rest.toml
@@ -11,8 +11,8 @@
 #                               true|false [=false].
 
 rest=false
-rest-address=
-rest-port=
-rest-relay-cache-capacity=
+#rest-address=
+#rest-port=
+#rest-relay-cache-capacity=
 #rest-admin=
-rest-private=
+#rest-private=

--- a/config/traits/rln.toml
+++ b/config/traits/rln.toml
@@ -1,0 +1,39 @@
+# --rln-relay               Enable spam protection through rln-relay:
+#                               true|false [=false].
+# --rln-relay-cred-path     The path for peristing rln-relay credential.
+# --rln-relay-membership-index  (experimental) the index of node in the rln-relay
+#                               group: a value between 0-99 inclusive [=0].
+# --rln-relay-pubsub-topic  the pubsub topic for which rln-relay gets enabled
+#                               [=/waku/2/default-waku/proto].
+# --rln-relay-content-topic  the pubsub topic for which rln-relay gets enabled
+#                               [=/toy-chat/2/luzhou/proto].
+# --rln-relay-dynamic       Enable  waku-rln-relay with on-chain dynamic
+#                               group management: true|false [=false].
+# --rln-relay-id-key        Rln relay identity secret key as a Hex string.
+# --rln-relay-id-commitment-key  Rln relay identity commitment key as a Hex
+#                               string.
+# --rln-relay-eth-account-address  Account address for the Ethereum testnet Goerli.
+# --rln-relay-eth-account-private-key  Account private key for the Ethereum testnet
+#                               Goerli.
+# --rln-relay-eth-client-address  WebSocket address of an Ethereum testnet client
+#                               e.g., ws://localhost:8540/
+#                               [=ws://localhost:8540/].
+# --rln-relay-eth-contract-address  Address of membership contract on an Ethereum
+#                               testnet.
+# --rln-relay-cred-password  Password for encrypting RLN credentials.
+
+
+
+rln-relay=false
+rln-relay-cred-path=
+rln-relay-membership-index=
+rln-relay-pubsub-topic="/waku/2/default-waku/proto"
+rln-relay-content-topic="/toy-chat/2/luzhou/proto"
+rln-relay-dynamic=false
+rln-relay-id-key=
+rln-relay-id-commitment-key=
+rln-relay-eth-account-address=
+rln-relay-eth-account-private-key=
+rln-relay-eth-client-address="ws://localhost:8540/"
+rln-relay-eth-contract-address=
+rln-relay-cred-password=

--- a/config/traits/rln.toml
+++ b/config/traits/rln.toml
@@ -25,15 +25,15 @@
 
 
 rln-relay=false
-rln-relay-cred-path=
-rln-relay-membership-index=
+#rln-relay-cred-path=
+#rln-relay-membership-index=
 rln-relay-pubsub-topic="/waku/2/default-waku/proto"
 rln-relay-content-topic="/toy-chat/2/luzhou/proto"
 rln-relay-dynamic=false
-rln-relay-id-key=
-rln-relay-id-commitment-key=
-rln-relay-eth-account-address=
-rln-relay-eth-account-private-key=
+#rln-relay-id-key=
+#rln-relay-id-commitment-key=
+#rln-relay-eth-account-address=
+#rln-relay-eth-account-private-key=
 rln-relay-eth-client-address="ws://localhost:8540/"
-rln-relay-eth-contract-address=
-rln-relay-cred-password=
+#rln-relay-eth-contract-address=
+#rln-relay-cred-password=

--- a/config/traits/rpc.toml
+++ b/config/traits/rpc.toml
@@ -1,0 +1,14 @@
+# --rpc                     Enable Waku JSON-RPC server: true|false [=true].
+# --rpc-address             Listening address of the JSON-RPC server.
+#                               [=ValidIpAddress.init("127.0.0.1")].
+# --rpc-port                Listening port of the JSON-RPC server. [=8545].
+# --rpc-admin               Enable access to JSON-RPC Admin API: true|false
+#                               [=false].
+# --rpc-private             Enable access to JSON-RPC Private API: true|false
+#                               [=false].
+
+rpc=true
+rpc-address="127.0.0.1"
+rpc-port=8545
+rpc-admin=false
+rpc-private=false

--- a/config/traits/store.toml
+++ b/config/traits/store.toml
@@ -13,9 +13,9 @@
 #                               boot..
 
 store=false
-storenode=
-store-message-retention-policy=
-store-message-db-url=
+#storenode=
+#store-message-retention-policy=
+#store-message-db-url=
 store-message-db-vacuum=false
 store-message-db-migration=true
-store-resume-peer=
+#store-resume-peer=

--- a/config/traits/store.toml
+++ b/config/traits/store.toml
@@ -1,0 +1,21 @@
+# --store                   Enable/disable waku store protocol [=false].
+# --storenode               Peer multiaddress to query for storage.
+# --store-message-retention-policy  Message store retention policy. Time retention
+#                               policy: 'time:<seconds>'. Capacity retention
+#                               policy: 'capacity:<count>'. Set to 'none' to
+#                               disable. [="time:" & $2.days.seconds].
+# --store-message-db-url    The database connection URL for peristent
+#                               storage. [=sqlite://store.sqlite3].
+# --store-message-db-vacuum  Enable database vacuuming at start. Only
+#                               supported by SQLite database engine. [=false].
+# --store-message-db-migration  Enable database migration at start. [=true].
+# --store-resume-peer       Peer multiaddress to resume the message store at
+#                               boot..
+
+store=false
+storenode=
+store-message-retention-policy=
+store-message-db-url=
+store-message-db-vacuum=false
+store-message-db-migration=true
+store-resume-peer=

--- a/config/traits/swap.toml
+++ b/config/traits/swap.toml
@@ -1,0 +1,4 @@
+#  --swap                    Enable swap protocol: true|false [=false].
+#                               messages.
+
+swap=false

--- a/config/traits/websocket.toml
+++ b/config/traits/websocket.toml
@@ -1,0 +1,12 @@
+# --websocket-support       Enable websocket:  true|false [=false].
+# --websocket-port          WebSocket listening port. [=8000].
+# --websocket-secure-support  Enable secure websocket:  true|false [=false].
+# --websocket-secure-key-path  Secure websocket key path:   '/path/to/key.txt' .
+# --websocket-secure-cert-path  Secure websocket Certificate path:
+#                               '/path/to/cert.txt' .
+
+websocket-support=false
+websocket-port=
+websocket-secure-support=
+websocket-secure-key-path=
+websocket-secure-cert-path=

--- a/config/traits/websocket.toml
+++ b/config/traits/websocket.toml
@@ -6,7 +6,7 @@
 #                               '/path/to/cert.txt' .
 
 websocket-support=false
-websocket-port=
-websocket-secure-support=
-websocket-secure-key-path=
-websocket-secure-cert-path=
+websocket-port=8000
+#websocket-secure-support=
+#websocket-secure-key-path=
+#websocket-secure-cert-path=

--- a/gennet-module/gennet.py
+++ b/gennet-module/gennet.py
@@ -255,12 +255,28 @@ def dict_to_arrays(dic):
         vals.append(dic[k])
     return keys, vals
 
+# Check for range failures in a list
+def range_fails(lst, min=0, max=100):
+    return any(x < min or x > max for x in lst)
+
+# Check for sum failures in a list
+def sum_fails(lst, sum_expected=100):
+    return not sum(lst) == sum_expected
+
+# Sanity check and extract the traits distribution
+def extract_trait_distribution(traits_distribution):
+    traits, traits_percentages = dict_to_arrays(traits_distribution)
+    if range_fails(traits_percentages) or sum_fails(traits_percentages) :
+        raise ValueError(
+                f"--node-type-distribution {traits_distribution} is invalid")
+    return traits, traits_percentages
+
 
 # Generate a list of nodeType enums that respects the node type distribution
 def generate_node_types(node_type_distribution, G):
     num_nodes = G.number_of_nodes()
-    nodes, node_probs = dict_to_arrays(node_type_distribution)
-    node_types_str = random.choices(nodes, weights=node_probs, k=num_nodes)
+    nodes, node_percentages = extract_trait_distribution(node_type_distribution)
+    node_types_str = random.choices(nodes, weights=node_percentages, k=num_nodes)
     node_types_enum = [nodeType(s) for s in node_types_str]
     return node_types_enum
 

--- a/gennet-module/gennet.py
+++ b/gennet-module/gennet.py
@@ -265,13 +265,19 @@ def generate_node_types(node_type_distribution, G):
     return node_types_enum
 
 # Inverts a dictionary of lists
-def invert_dict_of_list(d):
+def invert_dict_of_list(d, idx=0):
     inv = {}
     for key, val in d.items():
-        if val not in inv:
-            inv[val] = [key]
+        if idx == 0:
+            if val not in inv:
+                inv[val] = [key]
+            else:
+                inv[val].append(key)
         else:
-            inv[val].append(key)
+            if val[1] not in inv:
+                inv[val[1]] = [key]
+            else:
+                inv[val[1]].append(key)
     return inv
 
 
@@ -296,16 +302,11 @@ def generate_and_write_files(ctx: typer, G):
     node2subnet = generate_subnets(G, ctx.params["num_subnets"])
     node_types_enum = generate_node_types(ctx.params["node_type_distribution"], G)
     node2container = pack_nodes(ctx.params["container_size"], node2subnet, G)
+    inv = invert_dict_of_list(node2container, 1)
 
     json_dump = {}
     json_dump[CONTAINER_PREFIX] = {}
     json_dump[EXTERNAL_NODES_PREFIX] = {}
-    inv = {}
-    for key, val in node2container.items():
-        if val[1] not in inv:
-            inv[val[1]] = [key]
-        else:
-            inv[val[1]].append(key)
     for container, nodes in inv.items():
         json_dump[CONTAINER_PREFIX][container] = nodes
 

--- a/gennet-module/gennet.py
+++ b/gennet-module/gennet.py
@@ -73,6 +73,7 @@ NW_DATA_FNAME = "network_data.json"
 EXTERNAL_NODES_PREFIX, NODE_PREFIX, SUBNET_PREFIX, CONTAINER_PREFIX = \
     "nodes", "node", "subnetwork", "containers"
 ID_STR_SEPARATOR = "-"
+TRAITS_DIR="traits"
 
 ### I/O related fns ##############################################################
 
@@ -270,7 +271,7 @@ def generate_toml(topics, traits_list):
         topic_str = f"\"{topic_str}\""
 
     for trait in traits_list[1:] :
-        with open(f"traits/{trait}.toml", 'rb') as f:
+        with open(f"{TRAITS_DIR}/{trait}.toml", 'rb') as f:
             toml = ""
             for key, value in tomli.load(f).items():
                 toml += f"{key} = {str(value)}\n"

--- a/gennet-module/gennet.py
+++ b/gennet-module/gennet.py
@@ -264,7 +264,7 @@ def generate_node_types(node_type_distribution, G):
     node_types_enum = [nodeType(s) for s in node_types_str]
     return node_types_enum
 
-# Inverts a dictionary of lists
+# Inverts a dictionary of lists (of lists/tuples) 
 def invert_dict_of_list(d, idx=0):
     inv = {}
     for key, val in d.items():
@@ -285,10 +285,10 @@ def invert_dict_of_list(d, idx=0):
 # Number of containers = 
 #   $$ O(\sum_{i=0}^{num_subnets} log_{container_size}(#Nodes_{numsubnets}) + num_subnets)
 def pack_nodes(container_size, node2subnet, G):
-    subnet2node = invert_dict_of_list(node2subnet)
+    subnet2nodes = invert_dict_of_list(node2subnet)
     port_shift, cid, node2container = 0, 0, {}
-    for subnet in subnet2node:
-        for node in subnet2node[subnet]:
+    for subnet in subnet2nodes:
+        for node in subnet2nodes[subnet]:
             if port_shift >= container_size :
                 port_shift, cid = 0, cid+1
             node2container[node] = (port_shift, f"{CONTAINER_PREFIX}_{cid}")
@@ -302,12 +302,12 @@ def generate_and_write_files(ctx: typer, G):
     node2subnet = generate_subnets(G, ctx.params["num_subnets"])
     node_types_enum = generate_node_types(ctx.params["node_type_distribution"], G)
     node2container = pack_nodes(ctx.params["container_size"], node2subnet, G)
-    inv = invert_dict_of_list(node2container, 1)
+    container2nodes = invert_dict_of_list(node2container, 1)
 
     json_dump = {}
     json_dump[CONTAINER_PREFIX] = {}
     json_dump[EXTERNAL_NODES_PREFIX] = {}
-    for container, nodes in inv.items():
+    for container, nodes in container2nodes.items():
         json_dump[CONTAINER_PREFIX][container] = nodes
 
     i = 0


### PR DESCRIPTION
Gennet can now handle **all** the parameters of nwaku and most of gowaku parameters

- Each node / a set of nodes can now  select/set any and all of the akunode  parameters.
- Each logical category (say rln, relay, filter, lightpush, discv5, store etc) is now added as a trait and these traits are specified as a trait string. A trait string looks like "nwaku:rln:discv5:store": this specifies a nwaku node with store, discv5, rln capabilities.
- Each trait has a toml associated with it and Gennet composes these tomls to get the final, per-node toml
- The node distributions can be specified as {"nwaku:rln:discv5:store":80, "gowaku:dnsdisc:swap":20}. the values are percentages. Appropriate validations are added to the code.
- User defined traits can be added.

fixes #62 
