### PR TITLE
Alberto/cadvisor bandwidth into master

### DIFF
--- a/analysis-module/src/plotting_configurations.py
+++ b/analysis-module/src/plotting_configurations.py
@@ -17,6 +17,7 @@ plotting_config = {
         "xtic_labels": [
             "Received (Rx)"
         ],
+        "statistic": "max",
         "toMB": True
     },
     "container_network_transmit_bytes_total": {
@@ -28,6 +29,7 @@ plotting_config = {
         "xtic_labels": [
             "Sent (Tx)"
         ],
+        "statistic": "max",
         "toMB": True
     },
     "container_fs_reads_bytes_total": {
@@ -39,6 +41,7 @@ plotting_config = {
         "xtic_labels": [
             "Read"
         ],
+        "statistic": "max",
         "toMB": True
     },
     "container_fs_writes_bytes_total": {
@@ -50,6 +53,7 @@ plotting_config = {
         "xtic_labels": [
             "Write"
         ],
+        "statistic": "max",
         "toMB": True
     }
 }

--- a/analysis-module/src/prometheus.py
+++ b/analysis-module/src/prometheus.py
@@ -35,8 +35,8 @@ def get_hardware_metrics(metrics, topology, min_tss, max_tss, prom_port):
             analysis_logger.G_LOGGER.error('%s: %s' % (e.__doc__, e))
             continue
 
-    fetch_cadvisor_stats_from_prometheus_by_simulation(metrics, prometheus, container_ips, min_tss,
-                                                       max_tss)
+    #fetch_cadvisor_stats_from_prometheus_by_simulation(metrics, prometheus, container_ips, min_tss,
+    #                                                   max_tss)
 
 
 def fetch_cadvisor_stats_from_prometheus_by_simulation(metrics, prom, container_ips, start_ts,
@@ -117,5 +117,5 @@ def fetch_metric_with_timestamp(prom, metric, ip, start_timestamp, end_timestamp
 function_dispatcher = {
     "max": max,
     "min": min,
-    "average": lambda x: sum(x) / len(x),
+    "average": lambda x: sum(x) / len(x)
 }

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ else
   echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
   sudo apt update
   sudo apt-mark unhold kurtosis-cli
-  sudo apt install kurtosis-cli=$kurtosis_version
+  sudo apt install kurtosis-cli=$required_version
   sudo apt-mark hold kurtosis-cli
   sudo rm /etc/apt/sources.list.d/kurtosis.list
 fi

--- a/config/config.json
+++ b/config/config.json
@@ -56,13 +56,11 @@
     },
     "by_node": [
       "container_cpu_load_average_10s",
-      "container_memory_usage_bytes"
-    ],
-    "by_simulation": [
-        "container_network_receive_bytes_total",
-        "container_network_transmit_bytes_total",
-        "container_fs_reads_bytes_total",
-        "container_fs_writes_bytes_total"
+      "container_memory_usage_bytes",
+      "container_network_receive_bytes_total",
+      "container_network_transmit_bytes_total",
+      "container_fs_reads_bytes_total",
+      "container_fs_writes_bytes_total"
     ]
   }
 }


### PR DESCRIPTION
Quick change to cAdvisor plotting.

Before this change, `"by_simulation"` in `config.json` ment that these metrics would be aggregated per timestamp.

For example, if we have 60 timestamps and 10 containers, for each timestamp, I was aggregating the metric for all nodes in timestamp 1, then in timestamp 2... etc.

This was my bad since I understood this wrongly when we talked about "accumulated" values.

Now this is fixed. Values in `config.json` `"by_node"`, will behave correctly.
Bandwidth and Disk I/O are already accumulated in cadvisor, so we are just getting the maxmum value from all timestamps, and this is the plotted value.

Remember that cAdvisor does not divide metrics per **container**.