### PR TITLE
fix: replace plan.assert with plan.verify

### DIFF
--- a/src/assertions.star
+++ b/src/assertions.star
@@ -22,7 +22,7 @@ def start_test(plan, kurtosis_config, network_topology):
                                                         vars.WAKU_RPC_PORT_ID + vars.ID_STR_SEPARATOR + service_name,
                                                         values["endpoint"], extract)
 
-            plan.assert(value=response["code"], assertion="==", target_value = 200)
-            plan.assert(value=response["extract.jq_extract"], assertion=">",
+            plan.verify(value=response["code"], assertion="==", target_value = 200)
+            plan.verify(value=response["extract.jq_extract"], assertion=">",
                 target_value=values["expected_value"])
             plan.remove_service(service_info["container_id"])

--- a/src/node_builders/tests/test_node_builders.star
+++ b/src/node_builders/tests/test_node_builders.star
@@ -14,9 +14,9 @@ def test_instantiate_services(plan):
     node_builders.instantiate_services(plan, topology, False, True)
 
     for node_info in topology["nodes"].values():
-        plan.assert(value="peer_id", assertion="IN", target_value=node_info.keys())
-        plan.assert(value="ip_address", assertion="IN", target_value=node_info.keys())
-        plan.assert(value="ports", assertion="IN", target_value=node_info.keys())
+        plan.verify(value="peer_id", assertion="IN", target_value=node_info.keys())
+        plan.verify(value="ip_address", assertion="IN", target_value=node_info.keys())
+        plan.verify(value="ports", assertion="IN", target_value=node_info.keys())
 
     node_builders.interconnect_nodes(plan, topology, 1)
     _test_node_neighbours(plan, topology)
@@ -28,6 +28,6 @@ def test_instantiate_services(plan):
 def _test_node_neighbours(plan, topology):
     for node_name, node_info in topology["nodes"].items():
         peers = waku.get_waku_peers(plan, node_info["container_id"], node_name)
-        plan.assert(value=peers, assertion="==", target_value=1)
+        plan.verify(value=peers, assertion="==", target_value=1)
 
 

--- a/src/node_builders/types/tests/test_gowaku_builder.star
+++ b/src/node_builders/types/tests/test_gowaku_builder.star
@@ -16,29 +16,29 @@ def test_prepare_gowaku_service(plan):
                                           "id_1", topology, False)
 
     # hasattr doesn't work in dicts?
-    plan.assert(value=str(test_dict.get("id_1")),
+    plan.verify(value=str(test_dict.get("id_1")),
         assertion="!=", target_value="None")
 
-    plan.assert(value=test_dict["id_1"].image,
+    plan.verify(value=test_dict["id_1"].image,
         assertion="==", target_value=vars.GOWAKU_IMAGE)
 
     for node in ["test1", "test2"]:
-        plan.assert(value=str(test_dict["id_1"].ports[vars.WAKU_RPC_PORT_ID+vars.ID_STR_SEPARATOR+node].number),
+        plan.verify(value=str(test_dict["id_1"].ports[vars.WAKU_RPC_PORT_ID+vars.ID_STR_SEPARATOR+node].number),
             assertion="==", target_value = str(vars.WAKU_RPC_PORT_NUMBER +
                                                topology["nodes"][node][vars.GENNET_PORT_SHIFT_KEY]))
-        plan.assert(value=str(test_dict["id_1"].ports[vars.PROMETHEUS_PORT_ID+vars.ID_STR_SEPARATOR+node].number),
+        plan.verify(value=str(test_dict["id_1"].ports[vars.PROMETHEUS_PORT_ID+vars.ID_STR_SEPARATOR+node].number),
             assertion="==", target_value=str(vars.PROMETHEUS_PORT_NUMBER +
                                              topology["nodes"][node][vars.GENNET_PORT_SHIFT_KEY]))
-        plan.assert(value=str(test_dict["id_1"].ports[vars.WAKU_LIBP2P_PORT_ID+vars.ID_STR_SEPARATOR+node].number),
+        plan.verify(value=str(test_dict["id_1"].ports[vars.WAKU_LIBP2P_PORT_ID+vars.ID_STR_SEPARATOR+node].number),
                 assertion="==", target_value=str(vars.WAKU_LIBP2P_PORT +
                                                  topology["nodes"][node][vars.GENNET_PORT_SHIFT_KEY]))
 
     for node, file in zip(["test1", "test2"], ["a1", "a2"]):
-        plan.assert(value=test_dict["id_1"].files[vars.CONTAINER_NODE_CONFIG_FILE_LOCATION+node],
+        plan.verify(value=test_dict["id_1"].files[vars.CONTAINER_NODE_CONFIG_FILE_LOCATION+node],
                 assertion="==", target_value=file)
 
     for i in range(len(test_dict["id_1"].entrypoint)):
-        plan.assert(value=test_dict["id_1"].entrypoint[i], assertion="==",
+        plan.verify(value=test_dict["id_1"].entrypoint[i], assertion="==",
                 target_value=vars.GENERAL_ENTRYPOINT[i])
 
 
@@ -47,7 +47,7 @@ def test__prepare_gowaku_cmd_in_service(plan):
     topology = {"nodes": {"a": {"port_shift": 0}, "b": {"port_shift": 1}}}
     result = gowaku_builder._prepare_gowaku_cmd_in_service(["a", "b"], ["c", "d"], topology)
 
-    plan.assert(value=result[0],
+    plan.verify(value=result[0],
             assertion="==",
             target_value=vars.GOWAKU_ENTRYPOINT+" "+vars.WAKUNODE_CONFIGURATION_FILE_FLAG+
                 vars.CONTAINER_NODE_CONFIG_FILE_LOCATION+"a"+"/"+"c"+" "+

--- a/src/node_builders/types/tests/test_nwaku_builder.star
+++ b/src/node_builders/types/tests/test_nwaku_builder.star
@@ -15,33 +15,33 @@ def test_prepare_nwaku_service(plan):
                                         "id_1", topology, False)
 
     # hasattr doesn't work in dicts?
-    plan.assert(value=str(test_dict.get("id_1")),
+    plan.verify(value=str(test_dict.get("id_1")),
         assertion="!=", target_value="None")
 
-    plan.assert(value=test_dict["id_1"].image,
+    plan.verify(value=test_dict["id_1"].image,
         assertion="==", target_value=vars.NWAKU_IMAGE)
 
     for node in ["test1", "test2"]:
-        plan.assert(value=str(test_dict["id_1"].ports[vars.WAKU_RPC_PORT_ID+vars.ID_STR_SEPARATOR+node].number),
+        plan.verify(value=str(test_dict["id_1"].ports[vars.WAKU_RPC_PORT_ID+vars.ID_STR_SEPARATOR+node].number),
             assertion="==", target_value = str(vars.WAKU_RPC_PORT_NUMBER +
                                                topology["nodes"][node][vars.GENNET_PORT_SHIFT_KEY]))
-        plan.assert(value=str(test_dict["id_1"].ports[vars.PROMETHEUS_PORT_ID+vars.ID_STR_SEPARATOR+node].number),
+        plan.verify(value=str(test_dict["id_1"].ports[vars.PROMETHEUS_PORT_ID+vars.ID_STR_SEPARATOR+node].number),
             assertion="==", target_value=str(vars.PROMETHEUS_PORT_NUMBER +
                                              topology["nodes"][node][vars.GENNET_PORT_SHIFT_KEY]))
-        plan.assert(value=str(test_dict["id_1"].ports[vars.WAKU_LIBP2P_PORT_ID+vars.ID_STR_SEPARATOR+node].number),
+        plan.verify(value=str(test_dict["id_1"].ports[vars.WAKU_LIBP2P_PORT_ID+vars.ID_STR_SEPARATOR+node].number),
                 assertion="==", target_value=str(vars.WAKU_LIBP2P_PORT +
                                                  topology["nodes"][node][vars.GENNET_PORT_SHIFT_KEY]))
 
     for node, file in zip(["test1", "test2"], ["a1", "a2"]):
-        plan.assert(value=test_dict["id_1"].files[vars.CONTAINER_NODE_CONFIG_FILE_LOCATION+node],
+        plan.verify(value=test_dict["id_1"].files[vars.CONTAINER_NODE_CONFIG_FILE_LOCATION+node],
                 assertion="==", target_value=file)
 
     for node, file in zip(["test1", "test2"], ["run", "run"]):
-        plan.assert (value=test_dict["id_1"].files[vars.CONTAINER_NODE_SCRIPT_RUN_LOCATION],
+        plan.verify (value=test_dict["id_1"].files[vars.CONTAINER_NODE_SCRIPT_RUN_LOCATION],
         assertion="==", target_value=file)
 
     for i in range(len(test_dict["id_1"].entrypoint)):
-        plan.assert(value=test_dict["id_1"].entrypoint[i], assertion="==",
+        plan.verify(value=test_dict["id_1"].entrypoint[i], assertion="==",
                 target_value=vars.GENERAL_ENTRYPOINT[i])
 
 
@@ -50,7 +50,7 @@ def test__prepare_nwaku_cmd_in_service(plan):
     topology = {"nodes": {"a": {"port_shift": 0}, "b": {"port_shift": 1}}}
     result = nwaku_builder._prepare_nwaku_cmd_in_service(["a", "b"], ["c", "d"], topology)
 
-    plan.assert(value=result[0],
+    plan.verify(value=result[0],
             assertion="==",
             target_value=vars.CONTAINER_NODE_SCRIPT_RUN_LOCATION+
                 vars.NWAKU_SCRIPT_ENTRYPOINT+" "+vars.CONTAINER_NODE_CONFIG_FILE_LOCATION

--- a/src/node_builders/types/tests/test_waku_builder.star
+++ b/src/node_builders/types/tests/test_waku_builder.star
@@ -11,13 +11,13 @@ def test_prepare_waku_ports_in_service(plan):
     ports = waku_builders.prepare_waku_ports_in_service(["test1", "test2"], topology, False)
 
     for node_name in ["test1", "test2"]:
-        plan.assert(value=str(ports[vars.WAKU_RPC_PORT_ID+vars.ID_STR_SEPARATOR+node_name].number),
+        plan.verify(value=str(ports[vars.WAKU_RPC_PORT_ID+vars.ID_STR_SEPARATOR+node_name].number),
             assertion="==", target_value = str(vars.WAKU_RPC_PORT_NUMBER +
                                            topology["nodes"][node_name][vars.GENNET_PORT_SHIFT_KEY]))
-        plan.assert(value=str(ports[vars.PROMETHEUS_PORT_ID+vars.ID_STR_SEPARATOR+node_name].number),
+        plan.verify(value=str(ports[vars.PROMETHEUS_PORT_ID+vars.ID_STR_SEPARATOR+node_name].number),
             assertion="==", target_value=str(vars.PROMETHEUS_PORT_NUMBER +
                                              topology["nodes"][node_name][vars.GENNET_PORT_SHIFT_KEY]))
-        plan.assert(value=str(ports[vars.WAKU_LIBP2P_PORT_ID+vars.ID_STR_SEPARATOR+node_name].number),
+        plan.verify(value=str(ports[vars.WAKU_LIBP2P_PORT_ID+vars.ID_STR_SEPARATOR+node_name].number),
                 assertion="==", target_value=str(vars.WAKU_LIBP2P_PORT +
                                              topology["nodes"][node_name][vars.GENNET_PORT_SHIFT_KEY]))
 
@@ -29,9 +29,9 @@ def test_prepare_waku_config_files_in_service(plan):
     files = waku_builders.prepare_waku_config_files_in_service(names, artifact_ids, "run")
 
     for name, artif_id, run_id in zip(names, artifact_ids, run_artifact_id):
-        plan.assert(value=files[vars.CONTAINER_NODE_CONFIG_FILE_LOCATION+name],
+        plan.verify(value=files[vars.CONTAINER_NODE_CONFIG_FILE_LOCATION+name],
                     assertion="==", target_value=artif_id)
-        plan.assert (value=files[vars.CONTAINER_NODE_SCRIPT_RUN_LOCATION],
+        plan.verify (value=files[vars.CONTAINER_NODE_SCRIPT_RUN_LOCATION],
                     assertion="==", target_value=run_id)
 
 def test_add_waku_ports_info_to_topology(plan):
@@ -50,9 +50,9 @@ def test_add_waku_ports_info_to_topology(plan):
     waku_builders.add_waku_ports_info_to_topology(network_topology, services, node_info1, "test1",
                                                   False)
 
-    plan.assert(value=str(network_topology["nodes"]["test1"]["ports"][vars.WAKU_RPC_PORT_ID+"-test1"][0]),
+    plan.verify(value=str(network_topology["nodes"]["test1"]["ports"][vars.WAKU_RPC_PORT_ID+"-test1"][0]),
                 assertion="==", target_value=str(1))
-    plan.assert(value=str(network_topology["nodes"]["test1"]["ports"][vars.WAKU_LIBP2P_PORT_ID+"-test1"][0]),
+    plan.verify(value=str(network_topology["nodes"]["test1"]["ports"][vars.WAKU_LIBP2P_PORT_ID+"-test1"][0]),
                 assertion="==", target_value=str(2))
-    plan.assert(value=str(network_topology["nodes"]["test1"]["ports"][vars.PROMETHEUS_PORT_ID+"-test1"][0]),
+    plan.verify(value=str(network_topology["nodes"]["test1"]["ports"][vars.PROMETHEUS_PORT_ID+"-test1"][0]),
                 assertion="==", target_value=str(3))

--- a/src/nomos.star
+++ b/src/nomos.star
@@ -11,7 +11,7 @@ def get_nomos_peer_id(plan, service_name, port_id):
 
     response = call_protocols.send_http_get_req(plan, service_name, port_id, vars.NOMOS_NET_INFO_URL, extract)
 
-    plan.assert(value=response["code"], assertion="==", target_value = 200)
+    plan.verify(value=response["code"], assertion="==", target_value = 200)
 
     return response["extract.peer_id"]
 
@@ -34,7 +34,7 @@ def connect_nomos_to_peers(plan, service_name, node_id, port_id, peer_ids):
 
     response = call_protocols.send_http_post_req(plan, service_name, port_id, vars.NOMOS_NET_CONN_URL, body) 
 
-    plan.assert(value=response["code"], assertion="==", target_value = 200)
+    plan.verify(value=response["code"], assertion="==", target_value = 200)
 
     plan.print(response)
 

--- a/src/tests/test_arguments_parser.star
+++ b/src/tests/test_arguments_parser.star
@@ -10,7 +10,7 @@ def test_load_config_args_default(plan):
 
     parsed = arg_parser.get_configuration_file_name(plan, input_args)
 
-    plan.assert(value=parsed, assertion="==", target_value = vars.DEFAULT_CONFIG_FILE)
+    plan.verify(value=parsed, assertion="==", target_value = vars.DEFAULT_CONFIG_FILE)
 
 
 def test_load_config_args_given(plan):
@@ -18,4 +18,4 @@ def test_load_config_args_given(plan):
 
     parsed = arg_parser.get_configuration_file_name(plan, input_args)
 
-    plan.assert(value=parsed, assertion="==", target_value = "test.json")
+    plan.verify(value=parsed, assertion="==", target_value = "test.json")

--- a/src/tests/test_file_helpers.star
+++ b/src/tests/test_file_helpers.star
@@ -8,7 +8,7 @@ files = import_module(vars.FILE_HELPERS_MODULE)
 def test_get_toml_configuration_artifact_same_config_true(plan):
     artifact_id = files.get_toml_configuration_artifact(plan, "test.toml", "id_1", True)
 
-    plan.assert(value=artifact_id, assertion="==", target_value="id_1")
+    plan.verify(value=artifact_id, assertion="==", target_value="id_1")
 
 
 def test_get_toml_configuration_artifact_same_config_false(plan):
@@ -16,7 +16,7 @@ def test_get_toml_configuration_artifact_same_config_false(plan):
     # should be empty. test.toml file is there specifically for this test.
     artifact_id = files.get_toml_configuration_artifact(plan, "test.toml", "id_2", True)
 
-    plan.assert(value=artifact_id, assertion="==", target_value="id_2")
+    plan.verify(value=artifact_id, assertion="==", target_value="id_2")
 
 
 def test_generate_template_node_targets_single(plan):
@@ -25,7 +25,7 @@ def test_generate_template_node_targets_single(plan):
 
     template_data = files.generate_template_node_targets(network_topology, "rpc", "targets")
 
-    plan.assert(value=template_data["targets"], assertion="==", target_value='["1.1.1.1:80"]')
+    plan.verify(value=template_data["targets"], assertion="==", target_value='["1.1.1.1:80"]')
 
 
 def test_generate_template_node_targets_multiple(plan):
@@ -34,7 +34,7 @@ def test_generate_template_node_targets_multiple(plan):
 
     template_data = files.generate_template_node_targets(network_topology, "rpc", "targets")
 
-    plan.assert(value=template_data["targets"], assertion="==",
+    plan.verify(value=template_data["targets"], assertion="==",
                 target_value='["1.1.1.1:80","2.2.2.2:10"]')
 
 def test_generate_template_prometheus_url(plan):
@@ -43,11 +43,11 @@ def test_generate_template_prometheus_url(plan):
                                           PortSpec(number=vars.PROMETHEUS_PORT_NUMBER)})
 
     result = files.generate_template_prometheus_url(prometheus_service_struct)
-    plan.assert(value=result["prometheus_url"], assertion="==", target_value="1.2.3.4:8008")
+    plan.verify(value=result["prometheus_url"], assertion="==", target_value="1.2.3.4:8008")
 
 def test_prepare_artifact_files_grafana(plan):
     config, custom, dashboard = files.prepare_artifact_files_grafana(plan, "a", "b", "c")
 
-    plan.assert(value=config, assertion="==", target_value="a")
-    plan.assert(value=custom, assertion="==", target_value="b")
-    plan.assert(value=dashboard, assertion="==", target_value="c")
+    plan.verify(value=config, assertion="==", target_value="a")
+    plan.verify(value=custom, assertion="==", target_value="b")
+    plan.verify(value=dashboard, assertion="==", target_value="c")

--- a/src/tests/test_waku_methods.star
+++ b/src/tests/test_waku_methods.star
@@ -51,7 +51,7 @@ def test_get_wakunode_peer_id(plan, test_node, test_node_info, expected_ids):
     service_id = test_node_info[vars.GENNET_NODE_CONTAINER_KEY]
     peer_id = waku.get_wakunode_peer_id(plan, service_id, vars.WAKU_RPC_PORT_ID+vars.ID_STR_SEPARATOR+test_node)
     plan.print("Peer ID for " + test_node + ": " + peer_id)
-    plan.assert(value=peer_id, assertion="==", target_value=expected_ids[test_node])
+    plan.verify(value=peer_id, assertion="==", target_value=expected_ids[test_node])
 
 
 def test_create_node_multiaddress(plan):
@@ -61,7 +61,7 @@ def test_create_node_multiaddress(plan):
 
     waku_id = waku.create_node_multiaddress(node_id, node_information)
 
-    plan.assert(value=waku_id, assertion="==", target_value='"/ip4/1.1.1.1/tcp/1234/p2p/ASDFGHJKL"')
+    plan.verify(value=waku_id, assertion="==", target_value='"/ip4/1.1.1.1/tcp/1234/p2p/ASDFGHJKL"')
 
 
 def test__merge_peer_ids(plan):
@@ -69,7 +69,7 @@ def test__merge_peer_ids(plan):
 
     ids = waku._merge_peer_ids(waku_ids)
 
-    plan.assert(value=ids,
+    plan.verify(value=ids,
             assertion="==",
             target_value="[/ip4/1.1.1.1/tcp/1234/p2p/ASDFGHJKL,/ip4/2.2.2.2/tcp/1234/p2p/QWERTYUIOP]")
 
@@ -78,4 +78,4 @@ def test_get_waku_peers(plan, test_topology, expected):
     for test_node, test_node_info in test_topology["nodes"].items():
         num_peers = waku.get_waku_peers(plan, test_node_info["container_id"], test_node)
 
-        plan.assert(value=num_peers, assertion="==", target_value=expected)
+        plan.verify(value=num_peers, assertion="==", target_value=expected)

--- a/src/tests/test_wls.star
+++ b/src/tests/test_wls.star
@@ -9,14 +9,14 @@ def test_upload_config(plan):
     test_config = vars.TEST_FILES_LOCATION + "test_config_file.json"
     test = wls.upload_config(plan, test_config, "test_config")
 
-    plan.assert(value=test, assertion="==", target_value="test_config")
+    plan.verify(value=test, assertion="==", target_value="test_config")
 
 
 def test_create_new_topology_information(plan):
     test_topology = {}
     test = wls.create_new_topology_information(plan, test_topology, "test_topology")
 
-    plan.assert(value=test, assertion="==", target_value="test_topology")
+    plan.verify(value=test, assertion="==", target_value="test_topology")
 
 def test_create_cmd(plan):
     config_file = "test.json"
@@ -25,7 +25,7 @@ def test_create_cmd(plan):
               vars.WLS_TOPOLOGY_FILE_FLAG, vars.WLS_TOPOLOGY_PATH + vars.CONTAINER_TOPOLOGY_FILE_NAME_WLS]
 
     for i in range(len(result)):
-        plan.assert(value=test[i], assertion="==", target_value=result[i])
+        plan.verify(value=test[i], assertion="==", target_value=result[i])
 
 def test_init(plan):
     test_config = vars.TEST_FILES_LOCATION + "test_config_file.json"

--- a/src/waku.star
+++ b/src/waku.star
@@ -12,7 +12,7 @@ def get_wakunode_peer_id(plan, service_name, port_id):
     response = call_protocols.send_json_rpc(plan, service_name, port_id,
                              vars.GET_WAKU_INFO_METHOD, "", extract)
 
-    plan.assert(value=response["code"], assertion="==", target_value = 200)
+    plan.verify(value=response["code"], assertion="==", target_value = 200)
 
     return response["extract.peer_id"]
 
@@ -36,7 +36,7 @@ def connect_wakunode_to_peers(plan, service_name, node_id, port_id, peer_ids):
 
     response = call_protocols.send_json_rpc(plan, service_name, port_id, method, params)
 
-    plan.assert(value=response["code"], assertion="==", target_value = 200)
+    plan.verify(value=response["code"], assertion="==", target_value = 200)
 
     plan.print(response)
 
@@ -56,7 +56,7 @@ def get_waku_peers(plan, waku_service_container, node_name):
     response = call_protocols.send_json_rpc(plan, waku_service_container, port_name,
                                             vars.GET_PEERS_METHOD, "", extract)
 
-    plan.assert(value=response["code"], assertion="==", target_value=200)
+    plan.verify(value=response["code"], assertion="==", target_value=200)
 
     return response["extract.peers"]
 


### PR DESCRIPTION
Kurtosis is renaming `plan.assert` to `plan.verify` so popular Python linters & formatters can be run on `.star` scripts. We will be shipping a formatter with Kurtosis soon.

This change will work when the following - https://github.com/kurtosis-tech/kurtosis/pull/1295 is merged & released